### PR TITLE
Assign arrayLen as var to prevent calls on each iteration

### DIFF
--- a/week1/02.5_Script_vs_Tag.md
+++ b/week1/02.5_Script_vs_Tag.md
@@ -26,13 +26,15 @@ Let's look at some statements and compare the differences:
 
 ```cfml
 <cfset FruitArray = ["apple", "banana", "cherry"]>
-<cfloop from="1" to="#arrayLen( FruitArray)#" index="i">
+<cfset FruitLen = arrayLen(FruitArray)>
+<cfloop from="1" to="#FruitLen#" index="i">
     <cfoutput>#FruitArray[i]#</cfoutput>
 </cfloop>
 
 <cfscript>
     FruitArray = ["apple", "banana", "cherry"];
-    for( i=1; i <= arrayLen(FruitArray); i++){
+    FruitLen = arrayLen(FruitArray);
+    for (i = 1; i <= FruitLen; i++) {
         writeOutput(FruitArray[i]);
     }
 </cfscript>


### PR DESCRIPTION
If this isn't done, the arrayLen function is called on the array with each iteration. Thus, overhead is reduced by assigning the len as a variable.