### PR TITLE
Set arrayLen var; add missing cfoutput tags

### DIFF
--- a/week1/04.1_Looping.md
+++ b/week1/04.1_Looping.md
@@ -54,9 +54,10 @@ when looping over an array.
 
 ```cfml
 <cfset myArray = ['Jeff', 'John', 'Steve', 'Julianne']>
+<cfset myArrayLen = arrayLen(myArray)>
 
-<cfloop from="1" to="#arrayLen( myArray )#" index="i">
-    #i#: #myArray[i]#<br>
+<cfloop from="1" to="#myArrayLen#" index="i">
+  <cfoutput>#i#: #myArray[i]#<br></cfoutput>
 </cfloop>
 ```
 
@@ -78,7 +79,7 @@ not need the associated index.
 
 ```cfml
 <cfloop array="#myArray#" index="item">
-    #item#<br>
+    <cfoutput>#item#<br></cfoutput>
 </cfloop>
 ```
 
@@ -102,7 +103,7 @@ list loop is displayed in the code below:
 ```cfml
 <cfset myList = 'Jeff,John,Steve,Julliane'>
 <cfloop list="#myList#" index="item">
-    #item#<br>
+    <cfoutput>#item#<br></cfoutput>
 </cfloop>
 ```
 
@@ -110,8 +111,9 @@ If you need to keep track of the index as opposed to just the value of
 the current item position, you can use a standard iterative loop:
 
 ```cfml
-<cfloop from="1" to="#listlen( myList )#" index="i">
-    #i#: #listGetAt( myList, i )#<br>
+<cfset myListLen = listLen(myList)>
+<cfloop from="1" to="#myListLen#" index="i">
+    <cfoutput>#i#: #listGetAt( myList, i )#<br></cfoutput>
 </cfloop>
 ```
 
@@ -122,7 +124,7 @@ example allows you to break down a string into individual words:
 ```cfml
 <cfset myList = "This is the test sentence">
 <cfloop list="#myList#" index="word" delimiters=" ">
-    #word#<br>
+    <cfoutput>#word#<br></cfoutput>
 </cfloop>
 ```
 
@@ -144,7 +146,7 @@ can get the value for each key in a structure.
 <cfset myStruct = { name= 'Jeff Katersian', id= 12445, dob= '1/2/1994' }>
 
 <cfloop collection="#myStruct#" item="key">
-    #key#: #myStruct[key]#<br>
+    <cfoutput>#key#: #myStruct[key]#<br></cfoutput>
 </cfloop>
 ```
 
@@ -175,7 +177,7 @@ per query row.
 </cfscript>
 
 <cfloop query="myQuery">
-    #myQuery.id# #myQuery.user#<br>
+    <cfoutput>#myQuery.id# #myQuery.user#<br></cfoutput>
 </cfloop>
 ```
 
@@ -198,9 +200,10 @@ contains items.
 
 ```cfml
 <cfset myArray = ['Jeff', 'John', 'Steve', 'Julianne']>
+<cfset myArrayLen = arrayLen(myArray)>
 
-<cfloop condition="#arrayLen( myArray )#">
-    Current length = #arrayLen( myArray )#<br>
+<cfloop condition="#myArrayLen#">
+    <cfoutput>Current length = #myArrayLen#<br></cfoutput>
     <cfset arrayDeleteAt( myArray, 1 )>
 </cfloop>
 ```
@@ -229,7 +232,10 @@ available in CFML. Common cfscript loops are demonstrated below.
 
 ```cfml
 <cfscript>
-    for ( i=1; i<=arrayLen( myArray ); i++ ) {
+    myArray = ['Jeff', 'John', 'Steve', 'Julianne'];
+    myArrayLen = arrayLen(myArray);
+
+    for ( i = 1; i <= myArrayLen; i++ ) {
         writeOutput( '#i#: #myArray[i]#<br>' );
     }
 </cfscript>
@@ -238,6 +244,9 @@ available in CFML. Common cfscript loops are demonstrated below.
 ### Array Loop
 ```cfml
 <cfscript>
+    myArray = ['Jeff', 'John', 'Steve', 'Julianne'];
+    myArrayLen = arrayLen(myArray);
+
     for ( item in myArray ) {
         writeOutput( #item# & '<br>' );
     }
@@ -258,7 +267,7 @@ available in CFML. Common cfscript loops are demonstrated below.
 
 ```cfml
 <cfscript>
-    for ( i=1; i<=myQuery.recordCount; i++ ) {
+    for ( i = 1; i <= myQuery.recordCount; i++ ) {
         writeOutput( '#myQuery.id#: #myQuery.user[i]#<br>' );
     }
 </cfscript>
@@ -283,12 +292,12 @@ below:
 
 ```cfml
 <cfloop from="1" to="5" index="i">
-    #i#<br>
+    <cfoutput>#i#<br></cfoutput>
     <cfbreak>
 </cfloop>
 
 <cfscript>
-    for ( i=1; i<=5; i++ ) {
+    for ( i = 1; i <= 5; i++ ) {
         writeOutput( '#i#<br>' );
         break;
     }
@@ -312,11 +321,11 @@ keyword. Simple examples are provided below:
     <cfif i MOD 2 EQ 0>
         <cfcontinue>
     </cfif>
-    #i#<br>
+    <cfoutput>#i#<br></cfoutput>
 </cfloop>
 
 <cfscript>
-    for ( i=1; i<=5; i++ ) {
+    for ( i = 1; i <= 5; i++ ) {
         if ( i MOD 2 == 0 ) {
             continue;
         }


### PR DESCRIPTION
Setting an arrayLen as a var prevents duplicated calls, one for each iteration of the loop. Missing cfoutput tags rendered the text literally on output.