### PR TITLE
Application.cfc: fix targetPage reference w/r/t onRequestStart

### DIFF
--- a/week1/07.1_Applicationcfc.md
+++ b/week1/07.1_Applicationcfc.md
@@ -170,9 +170,8 @@ into community projects like
 
 ### onSessionStart, onRequestStart, and onRequestEnd
 
-These methods are very similar to `onApplicationStart` in their usage,
-with the one exception that `onRequestStart` is passed the targetPage as
-an argument. None of them need to return anything or are required to
+These methods are very similar to `onApplicationStart` in their usage. 
+None of them need to return anything or are required to
 operate in any specific way. The above samples pretty well summarize how
 you would write each of the Request Lifecycle Event methods, so we won't
 bore you by writing the same code sample over and over. You'll find a


### PR DESCRIPTION
It was brought to my attention that while all of the other references/examples in this chapter describe the `targetPage` argument correctly, it was incorrectly listed here as an arg of onRequestStart, which is not true.